### PR TITLE
QSP-1164 Skipped joining threads that were never started

### DIFF
--- a/src/qsp_protocol_node/audit/audit.py
+++ b/src/qsp_protocol_node/audit/audit.py
@@ -241,7 +241,9 @@ class QSPAuditNode:
         for thread in self.__internal_threads:
             if thread not in skip:
                 thread.join()
-            self.logger.debug("Thread {0} is joined and stopped.".format(thread.name))
+                self.logger.debug("Thread {0} is joined and stopped.".format(thread.name))
+            else:
+                self.logger.debug("Thread {0} does not need to be joined.".format(thread.name))
 
         self.__is_initialized = False
 

--- a/src/qsp_protocol_node/audit/audit.py
+++ b/src/qsp_protocol_node/audit/audit.py
@@ -227,18 +227,21 @@ class QSPAuditNode:
         self.__exec = False
         self.logger.info("Stopping QSP Audit Node")
 
+        skip = []
         # indicate to every thread that it should stop its execution
         for thread in self.__internal_threads:
-            self.logger.debug("Thread {0} is signaled to stop.".format(
-                    thread.name
-                )
-            )
-            thread.stop()
+            if thread.exec:
+                self.logger.debug("Thread {0} is signaled to stop.".format(thread.name))
+                thread.stop()
+            else:
+                skip += [thread]
+                self.logger.debug("Thread {0} was never started.".format(thread.name))
 
         # join every thread
         for thread in self.__internal_threads:
-            thread.join()
-            self.logger.debug("Thread {0} is stopped.".format(thread.name))
+            if thread not in skip:
+                thread.join()
+            self.logger.debug("Thread {0} is joined and stopped.".format(thread.name))
 
         self.__is_initialized = False
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This ensures that we do not attempt to join threads that were never started. 


## Motivation and Context

While stopping the node, we attempted to join threads regardless of whether they were started or not. This would be visible for example when running the node without stake---an exception would be thrown before starting any threads, and then the node would attempt to stop and join all the threads. This would cause more exceptions.

## How Has This Been Tested?

Interactive testing with docker and the bundle.

## Screenshots (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
