### PR TITLE
Include new Youtube video in nodemanual 

### DIFF
--- a/doc/node-operator.md
+++ b/doc/node-operator.md
@@ -263,7 +263,7 @@ you would need to change the line to `min_price_in_qsp: !!int 50000`.
 
 *Troubleshooting Tip: If you are updating `min_price_in_qsp`, make sure that you update this parameter for `mainnet` and not `testnet`.* 
 
-## Running the Node
+## Running the Node ([Click here](https://youtu.be/OZMlWXE82_w) to watch it on Youtube)
 In a terminal, open the directory of the qsp-protocol package you downloaded and unzipped at the beginning of this guide.
 
 ### Setting up your local machine configuration for every new Terminal opened


### PR DESCRIPTION
I include the latest Youtube Video Walkthrough video in the node operator manual. This video walks through how node operators can set their environment variables, run their node, confirm that their node successfully connected to the protocol and more. 

Here is the link to the video: https://youtu.be/OZMlWXE82_w

## Motivation and Context

It enhances the user experience by providing a visual walkthrough. Video's will reduce the UX friction. 
