### PR TITLE
Fixing hex output string in logs

### DIFF
--- a/src/qsp_protocol_node/audit/threads/submit_report_thread.py
+++ b/src/qsp_protocol_node/audit/threads/submit_report_thread.py
@@ -104,7 +104,7 @@ class SubmitReportThread(TimeIntervalPollingThread):
                                               request_id,
                                               audit_state,
                                               compressed_report_bytes))
-        self.logger.debug("Audit report submitted: tx hash {0}".format(tx_hash),
+        self.logger.debug("Audit report submitted: tx hash {0}".format(tx_hash.hex()),
                           requestId=request_id)
         return tx_hash
 
@@ -120,7 +120,7 @@ class SubmitReportThread(TimeIntervalPollingThread):
                                               request_id,
                                               compressed_report_bytes,
                                               is_verified))
-        self.logger.debug("Police report submitted: tx hash {0}".format(tx_hash),
+        self.logger.debug("Police report submitted: tx hash {0}".format(tx_hash.hex()),
                           requestId=request_id)
         return tx_hash
 

--- a/tests/audit/threads/test_submit_report.py
+++ b/tests/audit/threads/test_submit_report.py
@@ -5,6 +5,7 @@
 #                                                                                                  #
 ####################################################################################################
 
+from hexbytes import HexBytes
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -36,10 +37,11 @@ class TestSubmitReportThread(QSPTest):
         """
         tx_hash = self.__submit_thread._SubmitReportThread__submit_police_report(1, "", True)
         self.assertIsNotNone(tx_hash)
+        submission_hash = HexBytes('0x03087766bf68e78671d1ea436ae087da74a12761dac020011a9eddc4900bf13b')
         with mock.patch('audit.threads.submit_report_thread.send_signed_transaction',
-                        return_value="hash"):
+                        return_value=submission_hash):
             tx_hash = self.__submit_thread._SubmitReportThread__submit_police_report(1, "", True)
-            self.assertEquals(tx_hash, "hash")
+            self.assertEquals(tx_hash, submission_hash)
 
     def test_encoding_to_get_report_in_blockchain(self):
         compressed_report_bytes = b' \x03\x90\xb5U\xf2\xefS\'\xe1\x89`\x01\xd8tb\xe2\xe6\x9d\xa3\xda\xac\xe1\x8c\xb7\xb6\x0f"1$\x93\xa9\xc4\xf9\x05\x00\x0f\x0c\x00\x0f\r\x00\x0f\x05\x00\x13\x03\x00\x0f\x07\x00\x0f\x1a\x00\x0f\x15\x00\x06\x12\x00\x0e\x12\x00\n'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provides a fix for outputing transaction hashes in our logs. Previously, some logs were outputing the array of bytes returned by Web3. For logging purposes, this needs to be in a hexadecimal format.


## Motivation and Context

Having hexadecimals instead of a byte array helps us troubleshoot issues. Should have been that in the first place.

## How Has This Been Tested?

Unit testing


## Screenshots (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
