### PR TITLE
Retiring heartbeat config parameter - no longer needed at this point

### DIFF
--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -55,7 +55,6 @@ testnet:
     is_enabled: !!bool True
     interval_seconds: !!int 30
     destination_endpoint: !!str "https://protocol-staging.quantstamp.com/node-metrics"
-  heartbeat_allowed: !!bool False
 
 mainnet:
   eth_node:
@@ -101,4 +100,3 @@ mainnet:
     is_enabled: True
     interval_seconds: !!int 30
     destination_endpoint: !!str "https://protocol.quantstamp.com/node-metrics"
-  heartbeat_allowed: !!bool False

--- a/src/qsp_protocol_node/audit/threads/update_min_price_thread.py
+++ b/src/qsp_protocol_node/audit/threads/update_min_price_thread.py
@@ -99,9 +99,4 @@ class UpdateMinPriceThread(TimeIntervalPollingThread):
             polling_interval=24 * 60 * 60,
             thread_name="update min price thread")
 
-        if self.config.heartbeat_allowed:
-            # Updates min price and starts a thread that will be doing so every 24 hours
-            self.update_min_price()
-        else:
-            # Updates min price only if it differs
-            self.check_and_update_min_price()
+        self.check_and_update_min_price()

--- a/src/qsp_protocol_node/config/config.py
+++ b/src/qsp_protocol_node/config/config.py
@@ -113,7 +113,6 @@ class Config:
         self.__metric_collection_interval_seconds = config_value(cfg,
                                                                  '/metric_collection/interval_seconds',
                                                                  30)
-        self.__heartbeat_allowed = config_value(cfg, '/heartbeat_allowed', True)
         self.__enable_police_audit_polling = config_value(cfg, '/police/is_auditing_enabled', False)
 
     def __create_eth_provider(self, config_utils):
@@ -247,7 +246,6 @@ class Config:
         self.__web3_client = None
         self.__block_discard_on_restart = 0
         self.__contract_version = None
-        self.__heartbeat_allowed = True
         self.__enable_police_audit_polling = False
 
     @property
@@ -553,14 +551,6 @@ class Config:
         The version of the associated smart contract
         """
         return self.__node_version
-
-    @property
-    def heartbeat_allowed(self):
-        """
-        If true, the node will set min price using a blocking call upon startup and then every 24
-        hours. Otherwise, it will only update the min price if it differs.
-        """
-        return self.__heartbeat_allowed
 
     @property
     def enable_police_audit_polling(self):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -321,7 +321,6 @@ class TestConfig(QSPTest):
         self.assertEqual(0, config.start_n_blocks_in_the_past)
         self.assertEqual(6, config.n_blocks_confirmation)
         self.assertEqual(0, config.block_discard_on_restart)
-        self.assertTrue(config.heartbeat_allowed)
         self.assertFalse(config.enable_police_audit_polling)
 
     def test_create_components(self):
@@ -406,7 +405,6 @@ class TestConfig(QSPTest):
         self.assertEqual(2, len(config.analyzers))
         self.assertEqual(5, config.start_n_blocks_in_the_past)
         self.assertEqual(1, config.block_discard_on_restart)
-        self.assertFalse(config.heartbeat_allowed)
         self.assertFalse(config.enable_police_audit_polling)
 
     def test_inject_token_auth(self):

--- a/tests/resources/test_config.yaml
+++ b/tests/resources/test_config.yaml
@@ -46,7 +46,6 @@ dev:
     is_enabled: !!bool False
     interval_seconds: !!int 30
     destination_endpoint: !!str "https://localhost/node-metrics"
-  heartbeat_allowed: !!bool False
   police:
     # If set to False, the police node will never poll for regular audits
     is_auditing_enabled: !!bool False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Retires the `heartbeat_allowed` configuration parameter. No longer needed; it was originally intended for having nodes to periodically send a beat whether they are alive. The only usage as of today was to control the update of min audit price, which seems unrelated. The min audit price periodic check should occur regardless.


## Motivation and Context

Clean-up code

## How Has This Been Tested?

Unit testing (tested locally)
Must update our deployment repo (https://github.com/quantstamp/qsp-protocol-node-infra) to make it synch with this change

## Screenshots (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
