### PR TITLE
id -nG doesn't show "all" groups.

### DIFF
--- a/doc/node-operator.md
+++ b/doc/node-operator.md
@@ -153,7 +153,7 @@ the account to MetaMask so that you can stake QSP.
 
     The example above shows that the group owner is `staff`
 
-    Run command: `id -nG` to enumerate all the groups for the current user.
+    Run command: `id` to enumerate all the groups for the current user.
 
 1. ONLY On Linux environments (SKIP this step if you’re using MacOS), add the current user to that group (generally docker or root):
 `sudo usermod -a -G <group owner of docker.sock> <username>`


### PR DESCRIPTION
In https://github.com/quantstamp/qsp-protocol-node/blob/develop/doc/node-operator.md

I ran: 
Run the command: id -nG to enumerate all the groups for the current user.
in Ubuntu, but didn't show "all the groups"

Tried:
use just `id` instead. 

It works.