### PR TITLE
QSP-1171 Test speed up

### DIFF
--- a/src/qsp_protocol_node/config/config.py
+++ b/src/qsp_protocol_node/config/config.py
@@ -87,7 +87,7 @@ class Config:
                                                                '/block_mined_polling_interval_sec',
                                                                accept_none=False)
         self.__analyzers = []
-        self.__analyzers_config = config_value(cfg, '/analyzers', accept_none=False)
+        self.__analyzers_config = config_value(cfg, '/analyzers', [])
         self.__account_keystore_file = config_value(cfg, '/keystore_file', None)
         self.__account_private_key = None
         self.__gas_limit = config_value(cfg, '/gas_limit')

--- a/tests/audit/threads/test_claim_rewards.py
+++ b/tests/audit/threads/test_claim_rewards.py
@@ -18,19 +18,19 @@ from utils.eth import DeduplicationException
 
 
 class TestClaimRewards(QSPTest):
+    __CONFIG = None
 
     @classmethod
     def setUpClass(cls):
         QSPTest.setUpClass()
-        config = fetch_config(inject_contract=True)
-        remove(config.evt_db_path)
+        cls.__CONFIG = fetch_config(inject_contract=True,
+                                    filename="test_config_with_no_analyzers.yaml")
 
     def setUp(self):
-        self.__config = fetch_config(inject_contract=True)
-        self.__claim_rewards_thread = ClaimRewardsThread(self.__config)
+        self.__claim_rewards_thread = ClaimRewardsThread(TestClaimRewards.__CONFIG)
 
     def test_init(self):
-        self.assertEqual(self.__config, self.__claim_rewards_thread.config)
+        self.assertEqual(TestClaimRewards.__CONFIG, self.__claim_rewards_thread.config)
 
     @timeout(15, timeout_exception=StopIteration)
     def test_start_stop(self):
@@ -170,4 +170,4 @@ class TestClaimRewards(QSPTest):
         if self.__claim_rewards_thread.exec:
             self.__claim_rewards_thread.stop()
 
-        remove(self.__config.evt_db_path)
+        self.delete_events(TestClaimRewards.__CONFIG)

--- a/tests/audit/threads/test_collect_metrics.py
+++ b/tests/audit/threads/test_collect_metrics.py
@@ -15,23 +15,27 @@ from timeout_decorator import timeout
 
 
 class TestCollectMetricsThread(QSPTest):
+    __CONFIG = None
+
+    @classmethod
+    def setUpClass(cls):
+        QSPTest.setUpClass()
+        cls.__CONFIG = fetch_config(inject_contract=False,
+                                    filename="test_config_with_no_analyzers.yaml")
 
     def test_init(self):
-        config = fetch_config(inject_contract=True)
-        thread = CollectMetricsThread(config)
-        self.assertEqual(config, thread.config)
+        thread = CollectMetricsThread(TestCollectMetricsThread.__CONFIG)
+        self.assertEqual(TestCollectMetricsThread.__CONFIG, thread.config)
 
     def test_stop(self):
-        config = fetch_config(inject_contract=True)
-        thread = CollectMetricsThread(config)
+        thread = CollectMetricsThread(TestCollectMetricsThread.__CONFIG)
         thread.stop()
         self.assertFalse(thread.exec)
 
     @timeout(15, timeout_exception=StopIteration)
     def test_start_stop(self):
         # start the thread, signal stop and exit. use mock not to make work
-        config = fetch_config(inject_contract=True)
-        thread = CollectMetricsThread(config)
+        thread = CollectMetricsThread(TestCollectMetricsThread.__CONFIG)
         with mock.patch('audit.threads.collect_metrics_thread.MetricCollector.collect_and_send',
                         return_value=True):
             thread.start()

--- a/tests/audit/threads/test_compute_gas_price.py
+++ b/tests/audit/threads/test_compute_gas_price.py
@@ -14,37 +14,40 @@ from time import sleep
 
 
 class TestComputeGasPriceThread(QSPTest):
+    __CONFIG = None
+
+    @classmethod
+    def setUpClass(cls):
+        QSPTest.setUpClass()
+        cls.__CONFIG = fetch_config(inject_contract=False,
+                                    filename="test_config_with_no_analyzers.yaml")
 
     def test_init(self):
-        config = fetch_config(inject_contract=True)
-        thread = ComputeGasPriceThread(config)
-        self.assertEqual(config, thread.config)
+        thread = ComputeGasPriceThread(TestComputeGasPriceThread.__CONFIG)
+        self.assertEqual(TestComputeGasPriceThread.__CONFIG, thread.config)
 
     @timeout(30, timeout_exception=StopIteration)
     def test_gas_price_computation_static(self):
-        config = fetch_config(inject_contract=True)
-        thread = ComputeGasPriceThread(config)
+        config = fetch_config(inject_contract=False, filename="test_config_with_no_analyzers.yaml")
         config._Config__default_gas_price_wei = 12345
         config._Config__gas_price_strategy = "static"
+        thread = ComputeGasPriceThread(config)
         thread.compute_gas_price()
         self.assertEqual(config.gas_price_wei, 12345)
 
     @timeout(30, timeout_exception=StopIteration)
     def test_gas_price_computation_empty_blockchain(self):
-        config = fetch_config(inject_contract=True)
-        thread = ComputeGasPriceThread(config)
+        thread = ComputeGasPriceThread(TestComputeGasPriceThread.__CONFIG)
         # tests for errors when there are too few blocks in the blockchain history
         try:
             thread.compute_gas_price()
-            self.assertTrue(config.gas_price_wei > 0)
+            self.assertTrue(TestComputeGasPriceThread.__CONFIG.gas_price_wei > 0)
         except Exception:
             self.fail("Computing gas price on an empty blockchain failed.")
 
     @timeout(15, timeout_exception=StopIteration)
     def test_start_stop(self):
-        # start the thread, signal stop and exit. use mock not to make work
-        config = fetch_config(inject_contract=True)
-        thread = ComputeGasPriceThread(config)
+        thread = ComputeGasPriceThread(TestComputeGasPriceThread.__CONFIG)
         thread.start()
         while not thread.exec:
             sleep(0.1)

--- a/tests/audit/threads/test_submit_report.py
+++ b/tests/audit/threads/test_submit_report.py
@@ -16,13 +16,19 @@ from utils.io import fetch_file, load_json
 
 
 class TestSubmitReportThread(QSPTest):
+    __CONFIG = None
+
+    @classmethod
+    def setUpClass(cls):
+        QSPTest.setUpClass()
+        cls.__CONFIG = fetch_config(inject_contract=True,
+                                    filename="test_config_with_no_analyzers.yaml")
 
     def setUp(self):
         """
         Starts the execution of the QSP audit node as a separate thread.
         """
-        self.__config = fetch_config(inject_contract=True)
-        self.__submit_thread = SubmitReportThread(self.__config)
+        self.__submit_thread = SubmitReportThread(TestSubmitReportThread.__CONFIG)
 
     def test_get_report_in_blockchain_no_exception(self):
         """

--- a/tests/helpers/qsp_test.py
+++ b/tests/helpers/qsp_test.py
@@ -61,6 +61,12 @@ class QSPTest(unittest.TestCase):
         self.assertEqual(len([row for row in content if row in data]), len(data),
                          QSPTest.__find_difference(data, content))
 
+    def delete_events(self, config):
+        """Checks that the table audit_evt contains all dictionaries that are in data"""
+
+        query = "delete from audit_evt"
+        config.event_pool_manager.sql3lite_worker.execute(query)
+
     def compare_json(self, audit_file, report_file_path, json_loaded=False, ignore_id=False):
         if not json_loaded:
             actual_json = load_json(audit_file)

--- a/tests/helpers/resource.py
+++ b/tests/helpers/resource.py
@@ -71,9 +71,9 @@ def __load_audit_contract_from_src(web3_client, contract_src_uri, contract_name,
     return address, audit_contract
 
 
-def fetch_config(inject_contract=False):
+def fetch_config(inject_contract=False, filename="test_config.yaml"):
     # create config from file, the contract is not provided and will be injected separately
-    config_file_uri = resource_uri("test_config.yaml")
+    config_file_uri = resource_uri(filename)
     config = ConfigFactory.create_from_file(config_file_uri, os.getenv("QSP_ENV", default="dev"),
                                             validate_contract_settings=False)
     if inject_contract:

--- a/tests/resources/test_config_with_no_analyzers.yaml
+++ b/tests/resources/test_config_with_no_analyzers.yaml
@@ -1,0 +1,44 @@
+####################################################################################################
+#                                                                                                  #
+# (c) 2018, 2019 Quantstamp, Inc. This content and its use are governed by the license terms at    #
+# <https://s3.amazonaws.com/qsp-protocol-license/V2_LICENSE.txt>                                   #
+#                                                                                                  #
+####################################################################################################
+
+dev:
+  eth_node:
+    provider: !!str "EthereumTesterProvider" # (no args provided)
+  # audit_contract_abi: The contract is injected in tests
+  min_price_in_qsp: !!int 0
+  tx_timeout_seconds: !!int 300
+  gas_price:
+    # Can be set to one of ["fast" (expected to mine in < 60s)|"medium" (< 10 minutes)|"slow" (< 1 hour)|"fixed"]
+    strategy: !!str "dynamic"
+    # Only used if gas_strategy is set to "fixed", or if the other strategies somehow fail
+    default_gas_price_wei: !!int 0
+    # Sets an upper bound on gas_price which would override high values computed by the strategy.
+    # Useful in case the network gets "gas attacked".
+    max_gas_price_wei: !!int 20000000000
+  max_assigned_requests: !!int 1
+  evt_polling_sec: !!int 5
+  block_mined_polling_interval_sec: !!int 5
+  block_discard_on_restart: !!int 1
+
+  upload_provider:
+      is_enabled: !!bool True
+      name: !!str "S3Provider"
+      args:
+        bucket_name: !!str "qsp-protocol-reports-dev"
+        contract_bucket_name: !!str "qsp-protocol-reports-dev"
+  #account: No provided account hex (use the first one by default)
+  evt_db_path: !!str "/tmp/evts.test"
+  start_n_blocks_in_the_past: !!int 5
+  n_blocks_confirmation: !!int 0
+  metric_collection:
+    is_enabled: !!bool False
+    interval_seconds: !!int 30
+    destination_endpoint: !!str "https://localhost/node-metrics"
+  heartbeat_allowed: !!bool False
+  police:
+    # If set to False, the police node will never poll for regular audits
+    is_auditing_enabled: !!bool False


### PR DESCRIPTION
Refactores config handling in the thread tests.

## Description

- Creating new config with no analyzers
- Limiting recreating configs inside of thread tests


## Motivation and Context

The test suite takes long to execute. Two major slow downs are due to executing analyzer prefetching when the config instances are created, and injecting smart contract. By avoiding recreating the config files before every test (unless it is necessary) and removing analyzer wrappers when they are not needed, we achieve roughly 60% speed up in the relevant tests.

## How Has This Been Tested?

This is work on tests.

## Screenshots (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
