### PR TITLE
Fixing issue that one could not kill node if it were restarting itself

### DIFF
--- a/bin/qsp-protocol-node
+++ b/bin/qsp-protocol-node
@@ -11,13 +11,13 @@
 # Helper functions
 ################################################
 
-readonly SUCCESS="0"
-
 function kill_node() {
    echo "Node will not be launched. Stopping"
    exit 1
 }
 trap kill_node SIGTERM SIGINT
+
+readonly SUCCESS="0"
 
 function usage() {
     echo "usage: qsp-protocol-node [-t TEST_ENV] [-h] [-d] [-a AUTO_RESTART] [-f SOL_FILE]" &> /dev/stderr

--- a/bin/qsp-protocol-node
+++ b/bin/qsp-protocol-node
@@ -13,6 +13,12 @@
 
 readonly SUCCESS="0"
 
+function kill_node() {
+   echo "Node will not be launched. Stopping"
+   exit 1
+}
+trap kill_node SIGTERM SIGINT
+
 function usage() {
     echo "usage: qsp-protocol-node [-t TEST_ENV] [-h] [-d] [-a AUTO_RESTART] [-f SOL_FILE]" &> /dev/stderr
     echo "                      environment config-yaml"                                    &> /dev/stderr


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a long standing issue of not being able to kill the node when it is restarting itself.

Docker gives `qsp-protocol-node` PID 1, which interprets SIGKILL differently - i.e., it does not kill the program unless one sets a trap and exit.

## Motivation and Context

Change is required as a means to allow node operators to kill the node when it is rebooting itself.

## How Has This Been Tested?

Manually

1. By causing the node to restart itself (e.g., cut the network) and then do CTRL+C
2. By having the node to run as normal and then do CTRL+C

## Screenshots (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
