### PR TITLE
QSP-1235 Update chmod for default.json

### DIFF
--- a/doc/node-operator.md
+++ b/doc/node-operator.md
@@ -170,6 +170,9 @@ After you paste the contents of `[MyEtherWallet keystore file]` into `resources/
 ![](./node-operator/DEFAULT_FILE_COMPLETE_EXAMPLE.png)
 *Note: Not all of the code is visible in this image.* 
 
+Change the permissions for default.json so that only owner can read and write to the file: 
+
+`chmod 600 resources/keystore/default.json`
 
 
 ## Making your account eligible as a node operator ([Click here](https://youtu.be/3EeU_BCqAt0) to watch it on Youtube)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Update node operator manual to request users to change permissions for keystore/default.json to allow only file owner to be able to read and write 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the version in src/qsp_protocol_node/config/config.py
