### PR TITLE
QSP-1268 Fix local test docker failed tests

### DIFF
--- a/tests/analyzers/test_dockerhub_fail.py
+++ b/tests/analyzers/test_dockerhub_fail.py
@@ -68,8 +68,8 @@ class TestAnalyzerDockerhubFail(QSPTest):
         self.assertTrue(len(report['trace']) > 0)
         self.assertEquals(1, len(report['errors']))
         msg = "Error response from daemon: pull access denied for qspprotocol/" \
-              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'\n"
-        self.assertEquals(msg, report['errors'][0])
+              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'"
+        self.assertTrue(msg in report['errors'][0])
 
     def test_report_creation_once(self):
         """
@@ -92,8 +92,8 @@ class TestAnalyzerDockerhubFail(QSPTest):
         self.assertTrue(len(report['trace']) > 0)
         self.assertEquals(3, len(report['errors']))
         msg = "docker: Error response from daemon: pull access denied for qspprotocol/" \
-              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'.\n"
-        self.assertEquals(msg, report['errors'][1])
+              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'"
+        self.assertTrue(msg in report['errors'][1])
 
     def test_file_not_found(self):
         """
@@ -112,8 +112,8 @@ class TestAnalyzerDockerhubFail(QSPTest):
         self.assertTrue(len(report['errors']) > 0)
         self.assertTrue(len(report['trace']) > 0)
         msg = "Error response from daemon: pull access denied for qspprotocol/" \
-              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'\n"
-        self.assertEquals(msg, report['errors'][0])
+              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'"
+        self.assertTrue(msg in report['errors'][0])
 
     def test_file_not_found_once(self):
         """
@@ -154,8 +154,8 @@ class TestAnalyzerDockerhubFail(QSPTest):
         self.assertTrue(len(report['trace']) > 0)
         self.assertEquals(1, len(report['errors']))
         msg = "Error response from daemon: pull access denied for qspprotocol/" \
-              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'\n"
-        self.assertEquals(msg, report['errors'][0])
+              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'"
+        self.assertTrue(msg in report['errors'][0])
 
     def test_old_pragma_with_caret(self):
         """
@@ -173,8 +173,8 @@ class TestAnalyzerDockerhubFail(QSPTest):
         self.assertTrue(len(report['trace']) > 0)
         self.assertEquals(1, len(report['errors']))
         msg = "Error response from daemon: pull access denied for qspprotocol/" \
-              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'\n"
-        self.assertEquals(msg, report['errors'][0])
+              "does-not-exist-0.4.25, repository does not exist or may require 'docker login'"
+        self.assertTrue(msg in report['errors'][0])
 
 
 if __name__ == '__main__':

--- a/tests/helpers/qsp_test.py
+++ b/tests/helpers/qsp_test.py
@@ -101,7 +101,9 @@ class QSPTest(unittest.TestCase):
                 # Once scripts are either executed or skipped. The traces at position 1 differ.
                 "root['analyzers_reports'][0]['trace']",
                 "root['analyzers_reports'][1]['trace']",
-                "root['analyzers_reports'][2]['trace']"
+                "root['analyzers_reports'][2]['trace']",
+                "root['analyzers_reports'][0]['errors']",
+                "root['analyzers_reports'][1]['errors']"
             }
         )
         pprint(diff)

--- a/tests/resources/reports/DockerhubFail.json
+++ b/tests/resources/reports/DockerhubFail.json
@@ -12,7 +12,7 @@
     {
       "status": "error",
       "errors": [
-        "Error response from daemon: pull access denied for qspprotocol/does-not-exist-0.4.25, repository does not exist or may require 'docker login'\n"
+        "Error response from daemon: pull access denied for qspprotocol/does-not-exist-0.4.25, repository does not exist or may require 'docker login'"
       ],
       "trace": [
         ">> Wrapper setup finished\n",

--- a/tests/resources/reports/DockerhubFailAllAnalyzers.json
+++ b/tests/resources/reports/DockerhubFailAllAnalyzers.json
@@ -104,7 +104,7 @@
     {
       "status": "error",
       "errors": [
-        "Error response from daemon: pull access denied for qspprotocol/does-not-exist-0.4.25, repository does not exist or may require 'docker login'\n"
+        "Error response from daemon: pull access denied for qspprotocol/does-not-exist-0.4.25, repository does not exist or may require 'docker login'"
       ],
       "trace": [
         ">> Wrapper setup finished\n",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Local tests related to docker hub fail after upgrading to docker version >18 reason being that we do an exact match on the error string. Modified the tests to check for substring that works with both docker 18 and 19. This will allow both CI and local tests to pass
## Description

<!--- Describe your changes in detail -->


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the version in src/qsp_protocol_node/config/config.py
