### PR TITLE
QSP-1283: Default polling interval update

### DIFF
--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -18,7 +18,7 @@ testnet:
   tx_timeout_seconds: !!int 300
   max_assigned_requests: !!int 5
   evt_polling_sec: !!int 5
-  block_mined_polling_interval_sec: !!int 1
+  block_mined_polling_interval_sec: !!int 5
   block_discard_on_restart: !!int 1
   start_n_blocks_in_the_past: !!int 10
   n_blocks_confirmation: !!int 6
@@ -68,7 +68,7 @@ mainnet:
   tx_timeout_seconds: !!int 300
   max_assigned_requests: !!int 5
   evt_polling_sec: !!int 5
-  block_mined_polling_interval_sec: !!int 1
+  block_mined_polling_interval_sec: !!int 5
   block_discard_on_restart: !!int 1
   n_blocks_confirmation: !!int 6
   analyzers:


### PR DESCRIPTION
This is to make polling better for node operators using Infura (otherwise they run into throttling issues).

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the version in src/qsp_protocol_node/config/config.py
